### PR TITLE
HB-4558: Add initial podspec

### DIFF
--- a/ChartboostHeliumAdapterAdColony.podspec
+++ b/ChartboostHeliumAdapterAdColony.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
   spec.name        = 'ChartboostHeliumAdapterAdColony'
   spec.version     = '4.4.8.0.0'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
-  spec.homepage    = 'https://github.com/ChartBoost/helium-ios-adapter-chartboost'
+  spec.homepage    = 'https://github.com/ChartBoost/helium-ios-adapter-adcolony'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
   spec.summary     = 'Helium iOS SDK Ad Colony adapter.'
   spec.description = 'Ad Colony Adapters for mediating through Helium. Supported ad formats: Banner, Interstitial, and Rewarded.'


### PR DESCRIPTION
Add podspec to fulfill Canary app local dependency for development.
Partner SDK version may not be the final one we use when we release, whenever we work on the adapter we should review.