### PR TITLE
HB-4944: Fix banner loading

### DIFF
--- a/Source/AdColonyAdapterBannerAd.swift
+++ b/Source/AdColonyAdapterBannerAd.swift
@@ -31,6 +31,8 @@ final class AdColonyAdapterBannerAd: AdColonyAdapterAd, PartnerAd {
             return completion(.failure(error))
         }
         
+        loadCompletion = completion
+        
         let size = AdColonyAdSizeFromCGSize(request.size ?? IABStandardAdSize)
         let options = AdColonyAdOptions()
         options.setOption("adm", withStringValue: bidPayload)


### PR DESCRIPTION
The load completion was not being saved, therefore it was always nil when the load callback was called.