### PR TITLE
HB-4935: Simplify use of unknown errors in adapters

### DIFF
--- a/Source/AdColonyAdapterBannerAd.swift
+++ b/Source/AdColonyAdapterBannerAd.swift
@@ -63,9 +63,8 @@ extension AdColonyAdapterBannerAd: AdColonyAdViewDelegate {
     }
 
     func adColonyAdViewDidFail(toLoad partnerError: AdColonyAdRequestError) {
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
 

--- a/Source/AdColonyAdapterFullscreenAd.swift
+++ b/Source/AdColonyAdapterFullscreenAd.swift
@@ -84,9 +84,8 @@ extension AdColonyAdapterFullscreenAd: AdColonyInterstitialDelegate {
     }
 
     func adColonyInterstitialDidFail(toLoad partnerError: AdColonyAdRequestError) {
-        let error = error(.loadFailureUnknown, error: partnerError)
-        log(.loadFailed(error))
-        loadCompletion?(.failure(error)) ?? log(.loadResultIgnored)
+        log(.loadFailed(partnerError))
+        loadCompletion?(.failure(partnerError)) ?? log(.loadResultIgnored)
         loadCompletion = nil
     }
 


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-4935

Partner errors can now be directly used with `PartnerAdLogEvent` and the completion handlers, which will get auto-wrapped within a `HeliumError` with the appropriate `unknown` code, per the work done in https://github.com/ChartBoost/ios-helium-sdk/pull/882.