### PR TITLE
Fix podspec source tag

### DIFF
--- a/ChartboostHeliumAdapterAdColony.podspec
+++ b/ChartboostHeliumAdapterAdColony.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |spec|
 
   # Source
   spec.module_name  = 'HeliumAdapterAdColony'
-  spec.source       = { :git => 'https://github.com/ChartBoost/helium-ios-adapter-adcolony.git', :tag => '#{spec.version}' }
+  spec.source       = { :git => 'https://github.com/ChartBoost/helium-ios-adapter-adcolony.git', :tag => spec.version }
   spec.source_files = 'Source/**/*.{swift}'
   spec.static_framework = true
 


### PR DESCRIPTION
The current use of the `spec.version` variable is not being resolved to a proper tag string.
Changing to use the `spec.version` value directly, which I've validated locally it works.

**WARNING: I will not create PRs for all the adapters. Once this PR is approved I will directly push identical changes to all of them.**