### PR TITLE
HB-4911: Add adapter version match validation step to smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -16,6 +16,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # Check that the adapter version in the podpsec and in the PartnerAdapter Swift implementation are the same.
+      - name: Validate Adapter and Podspec Version Match
+        id: adapter_version_match
+        run: echo "result=$(ruby ./Scripts/validate_adapter_version.rb)" >> $GITHUB_OUTPUT
+        shell: bash
+
+      # Fail if versions don't match
+      - name: Fail on Adapter Version Mismatch
+        if: ${{ steps.adapter_version_match.outputs.result != 'true' }}
+        run: exit 1
+        shell: bash
+
       # Validate the podspec.
       - name: Validate Podspec
         run: pod lib lint --verbose

--- a/Scripts/adapter_version.rb
+++ b/Scripts/adapter_version.rb
@@ -1,14 +1,4 @@
-PODSPEC_PATH_PATTERN = "*.podspec"
-PODSPEC_VERSION_REGEX = /^\s*spec\.version\s*=\s*'([0-9]+.[0-9]+.[0-9]+.[0-9]+.[0-9]+(?>.[0-9]+)?)'\s*$/
+require_relative 'podspec_version'
 
-# Obtain the podspec file path
-file = Dir.glob(PODSPEC_PATH_PATTERN).first
-fail unless !file.nil?
-
-# Obtain the adapter version from the podspec
-text = File.read(file)
-version = text.match(PODSPEC_VERSION_REGEX).captures.first
-fail unless !version.nil?
-
-# Output to console
-puts version
+# Take podspec version as the adapter version and output to console
+puts podspec_version

--- a/Scripts/podspec_version.rb
+++ b/Scripts/podspec_version.rb
@@ -1,0 +1,17 @@
+PODSPEC_PATH_PATTERN = "*.podspec"
+PODSPEC_VERSION_REGEX = /^\s*spec\.version\s*=\s*'([0-9]+.[0-9]+.[0-9]+.[0-9]+.[0-9]+(?>.[0-9]+)?)'\s*$/
+
+# Returns the podspec version value.
+def podspec_version
+  # Obtain the podspec file path
+  file = Dir.glob(PODSPEC_PATH_PATTERN).first
+  fail unless !file.nil?
+
+  # Obtain the adapter version from the podspec
+  text = File.read(file)
+  version = text.match(PODSPEC_VERSION_REGEX).captures.first
+  fail unless !version.nil?
+  
+  # Return value
+  version
+end

--- a/Scripts/validate_adapter_version.rb
+++ b/Scripts/validate_adapter_version.rb
@@ -1,0 +1,29 @@
+require_relative 'podspec_version'
+
+PODSPEC_NAME_REGEX = /^\s*spec\.name\s*=\s*'([^']+)'\s*$/
+ADAPTER_VERSION_REGEX = /^\s*let adapterVersion\s*=\s*"([^"]+)".*$/
+
+# Obtain the podspec file path
+podspec_path = Dir.glob(PODSPEC_PATH_PATTERN).first
+fail unless !podspec_path.nil?
+
+# Obtain the adapter name from the podspec
+podspec = File.read(podspec_path)
+pod_name = podspec.match(PODSPEC_NAME_REGEX).captures.first
+fail unless !pod_name.nil?
+
+# Obtain the partner name
+partner_name = pod_name.delete_prefix "ChartboostMediationAdapter"
+fail unless !partner_name.nil?
+
+# Obtain the Adapter file path
+file = Dir.glob("./Source/#{partner_name}Adapter.swift").first
+fail unless !file.nil?
+
+# Obtain the adapter version from the Adapter file
+text = File.read(file)
+adapter_version = text.match(ADAPTER_VERSION_REGEX).captures.first
+fail unless !adapter_version.nil?
+
+# Output match result to console
+puts podspec_version == adapter_version


### PR DESCRIPTION
Assumes podspec name rename to “ChartboostMediationAdapter..."

Refactored podspec_version logic into a method so it can be reused in both scripts.