### PR TITLE
HB-5057: import ChartboostMediationSDK instead of HeliumSdk

### DIFF
--- a/Source/AdColonyAdapter.swift
+++ b/Source/AdColonyAdapter.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterAdColony
 //
 
-import Foundation
-import HeliumSdk
 import AdColony
+import ChartboostMediationSDK
+import Foundation
 import UIKit
 
 /// The Helium AdColony adapter.

--- a/Source/AdColonyAdapterAd.swift
+++ b/Source/AdColonyAdapterAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterAdColony
 //
 
-import Foundation
-import HeliumSdk
 import AdColony
+import ChartboostMediationSDK
+import Foundation
 import UIKit
 
 /// Base class for Helium AdColony adapter ads.

--- a/Source/AdColonyAdapterBannerAd.swift
+++ b/Source/AdColonyAdapterBannerAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterAdColony
 //
 
-import Foundation
-import HeliumSdk
 import AdColony
+import ChartboostMediationSDK
+import Foundation
 
 /// The Helium InMobi adapter banner ad.
 final class AdColonyAdapterBannerAd: AdColonyAdapterAd, PartnerAd {

--- a/Source/AdColonyAdapterFullscreenAd.swift
+++ b/Source/AdColonyAdapterFullscreenAd.swift
@@ -8,9 +8,9 @@
 //  ChartboostHeliumAdapterAdColony
 //
 
-import Foundation
-import HeliumSdk
 import AdColony
+import ChartboostMediationSDK
+import Foundation
 
 /// The Helium InMobi adapter fullscreen ad.
 final class AdColonyAdapterFullscreenAd: AdColonyAdapterAd, PartnerAd {


### PR DESCRIPTION
This is a companion PR of https://github.com/ChartBoost/ios-helium-sdk/pull/942.

Discussed with Dani and decided to merge the tedious adapter PR's without code review to speed up the whole rebranding process.