### PR TITLE
HB-5272: Support non-programmatic ad loads

### DIFF
--- a/Source/AdColonyAdapterBannerAd.swift
+++ b/Source/AdColonyAdapterBannerAd.swift
@@ -20,11 +20,6 @@ final class AdColonyAdapterBannerAd: AdColonyAdapterAd, PartnerAd {
     func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
         log(.loadStarted)
         
-        guard let bidPayload = request.adm, !bidPayload.isEmpty else {
-            let error = error(.loadFailureInvalidAdMarkup)
-            log(.loadFailed(error))
-            return completion(.failure(error))
-        }
         guard let viewController = viewController else {
             let error = error(.loadFailureViewControllerNotFound)
             log(.loadFailed(error))
@@ -35,7 +30,9 @@ final class AdColonyAdapterBannerAd: AdColonyAdapterAd, PartnerAd {
         
         let size = AdColonyAdSizeFromCGSize(request.size ?? IABStandardAdSize)
         let options = AdColonyAdOptions()
-        options.setOption("adm", withStringValue: bidPayload)
+        if let adm = request.adm {
+            options.setOption("adm", withStringValue: adm)
+        }
 
         AdColony.requestAdView(
             inZone: request.partnerPlacement,

--- a/Source/AdColonyAdapterFullscreenAd.swift
+++ b/Source/AdColonyAdapterFullscreenAd.swift
@@ -23,17 +23,12 @@ final class AdColonyAdapterFullscreenAd: AdColonyAdapterAd, PartnerAd {
     func load(with viewController: UIViewController?, completion: @escaping (Result<PartnerEventDetails, Error>) -> Void) {
         log(.loadStarted)
         
-        guard let bidPayload = request.adm, !bidPayload.isEmpty else {
-            let error = error(.loadFailureInvalidAdMarkup)
-            log(.loadFailed(error))
-            completion(.failure(error))
-            return
-        }
-        
         loadCompletion = completion
 
         let options = AdColonyAdOptions()
-        options.setOption("adm", withStringValue: bidPayload)
+        if let adm = request.adm {
+            options.setOption("adm", withStringValue: adm)
+        }
 
         if request.format == .rewarded {
             zone.setReward { [weak self] success, _, _ in


### PR DESCRIPTION
For non-programmatic we call the same AdColony methods, just passing an empty options object.

I was able to get fill with this fix.