### PR TITLE
HB-5431: Fix Github release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Create Release
         uses: actions/create-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          tag_name: ${{ steps.release_version.outputs.version }}
+          release_name: ${{ steps.release_version.outputs.version }}
           body: ''
           draft: false
           prerelease: false


### PR DESCRIPTION
Fixed GitHub release creation step in the release script, using the release version as the tag and name, instead of the branch name.