### PR TITLE
Update Version to 4.4.9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,5 +3,8 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.4.9.0.1
+- This version of the adapters has been certified with AdColony 4.9.0.
+
 ### 4.4.9.0.0
 - This version of the adapters has been certified with AdColony 4.9.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Note the first digit of every adapter version corresponds to the major version o
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
 ### 4.4.9.0.1
+- Add support for Adaptive Banners.
 - This version of the adapters has been certified with AdColony 4.9.0.
 
 ### 4.4.9.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Adapters are compatible with any Chartboost Mediation SDK version within that ma
 
 ### 4.4.9.0.1
 - Add support for Adaptive Banners.
+- No longer performing console logging on iOS 11.
 - This version of the adapters has been certified with AdColony 4.9.0.
 
 ### 4.4.9.0.0

--- a/ChartboostMediationAdapterAdColony.podspec
+++ b/ChartboostMediationAdapterAdColony.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name        = 'ChartboostMediationAdapterAdColony'
-  spec.version     = '4.4.9.0.0'
+  spec.version     = '4.4.9.0.1'
   spec.license     = { :type => 'MIT', :file => 'LICENSE.md' }
   spec.homepage    = 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-adcolony'
   spec.authors     = { 'Chartboost' => 'https://www.chartboost.com/' }
@@ -24,5 +24,5 @@ Pod::Spec.new do |spec|
   spec.dependency 'ChartboostMediationSDK', '~> 4.0'
 
   # Partner network SDK and version that this adapter is certified to work with.
-  spec.dependency 'AdColony', '4.9.0'
+  spec.dependency 'AdColony', '~> 4.9.0'
 end

--- a/Source/AdColonyAdapter.swift
+++ b/Source/AdColonyAdapter.swift
@@ -17,7 +17,7 @@ final class AdColonyAdapter: NSObject, PartnerAdapter {
     /// The version of the adapter.
     /// It should have either 5 or 6 digits separated by periods, where the first digit is Chartboost Mediation SDK's major version, the last digit is the adapter's build version, and intermediate digits are the partner SDK's version.
     /// Format: `<Chartboost Mediation major version>.<Partner major version>.<Partner minor version>.<Partner patch version>.<Partner build version>.<Adapter build version>` where `.<Partner build version>` is optional.
-    let adapterVersion = "4.4.9.0.0"
+    let adapterVersion = "4.4.9.0.1"
     
     /// The partner's unique identifier.
     let partnerIdentifier = "adcolony"

--- a/Source/AdColonyAdapter.swift
+++ b/Source/AdColonyAdapter.swift
@@ -152,7 +152,12 @@ final class AdColonyAdapter: NSObject, PartnerAdapter {
         case .banner:
             return AdColonyAdapterBannerAd(adapter: self, request: request, delegate: delegate, zone: zone)
         default:
-            throw error(.loadFailureUnsupportedAdFormat)
+            // Not using the `.adaptiveBanner` case directly to maintain backward compatibility with Chartboost Mediation 4.0
+            if request.format.rawValue == "adaptive_banner" {
+                return AdColonyAdapterBannerAd(adapter: self, request: request, delegate: delegate, zone: zone)
+            } else {
+                throw error(.loadFailureUnsupportedAdFormat)
+            }
         }
     }
     


### PR DESCRIPTION
Adapter version '4.4.9.0.1', partner version '~> 4.9.0'

This is an example of how all adapters will be updated to support loading fixed size banners inside adaptive banner placements.