### PR TITLE
[HB-6728] add privacy manifest

### DIFF
--- a/ChartboostMediationAdapterAdColony.podspec
+++ b/ChartboostMediationAdapterAdColony.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |spec|
   spec.module_name  = 'ChartboostMediationAdapterAdColony'
   spec.source       = { :git => 'https://github.com/ChartBoost/chartboost-mediation-ios-adapter-adcolony.git', :tag => spec.version }
   spec.source_files = 'Source/**/*.{swift}'
+  spec.resource_bundles = { 'ChartboostMediationAdapterAdColony' => ['PrivacyInfo.xcprivacy'] }
   spec.static_framework = true
 
   # Minimum supported versions

--- a/PrivacyInfo.xcprivacy
+++ b/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
Add a privacy manifest to explicitly indicate this CocoaPods does not have any privacy tracking concern.

There is no way to test this privacy manifest until it is publicly available, but we have until April 2023 to verify.

See http://go/privacy-manifests-and-cocoapods